### PR TITLE
Duration bug fixed

### DIFF
--- a/lib/Toast.js
+++ b/lib/Toast.js
@@ -35,14 +35,12 @@ class Toast extends Component {
     componentWillMount = () => {
         this._toast = new RootSiblings(<ToastContainer
             {...this.props}
-            duration={0}
         />);
     };
 
     componentWillReceiveProps = nextProps => {
         this._toast.update(<ToastContainer
             {...nextProps}
-            duration={0}
         />);
     };
 


### PR DESCRIPTION
Duration was being set to zero in the Toast wrapper, so the "duration" props was being ignored. Removed them and now the Toast automatically hides as expected, after the specified duration.